### PR TITLE
Fix pom.xml and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the following plugin to your pom.xml in the build -> plugins section:
         <execution>
             <phase>install</phase>
             <goals>
-                <goal>generate-readme</goal>
+                <goal>generate</goal>
             </goals>
             <configuration>
                 <sections>
@@ -26,7 +26,7 @@ Add the following plugin to your pom.xml in the build -> plugins section:
             </configuration>
         </execution>
     </executions>
-  <plugin>
+  </plugin>
 ```
 
  So that will generate the README.md in the root folder of the project with the information that can be extracted from the following tags:

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
                 <version>1.0-SNAPSHOT</version>
                 <executions>
                     <execution>
-                        <id>generate-readme</id>
+                        <id>generate</id>
                         <phase>install</phase>
                         <goals>
                             <goal>generate</goal>
@@ -127,7 +127,7 @@ Add the following plugin to your pom.xml in the build -> plugins section:
         <execution>
             <phase>install</phase>
             <goals>
-                <goal>generate-readme</goal>
+                <goal>generate</goal>
             </goals>
             <configuration>
                 <sections>
@@ -136,7 +136,7 @@ Add the following plugin to your pom.xml in the build -> plugins section:
             </configuration>
         </execution>
     </executions>
-  <plugin>
+  </plugin>
 ```
 
  So that will generate the README.md in the root folder of the project with the information that can be extracted from the following tags:

--- a/src/main/resources/README.md.tmpl
+++ b/src/main/resources/README.md.tmpl
@@ -23,4 +23,3 @@ $section
 #end
 
 #end
-Happy hacking!


### PR DESCRIPTION
I have created this pull request to:

- Fix pom.xml so that the goal is correct (_generate_ instead _generate-readme_) and the example configuration can be reused by copy and paste (plugin end tag was wrong).
- Fix the README.md template to remove the "Happy hacking" message which is not informative for users.

Thank you very much.